### PR TITLE
chore: rust audio do not return list if empty

### DIFF
--- a/RustAudio/Wrap/Libraries/librust_audio.dylib
+++ b/RustAudio/Wrap/Libraries/librust_audio.dylib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d32cb46ea48ea8d2dc85a39db1d897fb27f4f6eee2baf47d8196ad80ff860346
-size 694448
+oid sha256:dc4b57d0e999a9d265c9f39222957713b7b6784478fdb70daabafc1aab03e1e0
+size 694464

--- a/RustAudio/Wrap/Libraries/rust_audio.dll
+++ b/RustAudio/Wrap/Libraries/rust_audio.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8236fbf8deb339502cdd2d1f0bef8494011ce90ffa80fcfd91e31a48dfe3ce26
+oid sha256:c10ab4b89a2cb7475b16083412dc8394501a432dd5a3d39700c3731f4af664e8
 size 414720

--- a/RustAudio/rust-audio/src/lib.rs
+++ b/RustAudio/rust-audio/src/lib.rs
@@ -192,7 +192,11 @@ pub extern "C" fn rust_audio_input_device_names() -> DeviceNamesResult {
         Ok(names) => DeviceNamesResult {
             error_message: ptr::null(),
             length: names.len() as i32,
-            names: vec_to_c_array(names),
+            names: if names.len() > 0 {
+                vec_to_c_array(names)
+            } else {
+                ptr::null()
+            },
         },
         Err(e) => DeviceNamesResult {
             names: ptr::null(),


### PR DESCRIPTION
avoids unnecessary allocation when no audio inputs were found

case is already gracefully handles on the managed side