### PR TITLE
fix: spatial panning gain match to mono  + click prevention

### DIFF
--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -15,10 +15,19 @@ namespace LiveKit.Rooms.Streaming.Audio
     {
         public enum IldProfile : byte
         {
-            Subtle,   // α=1.2, ≈ −8 dB at 90° — average across voice band
-            Moderate, // α=1.5, ≈ −10 dB at 90° — slightly emphasized
-            Strong,   // α=2.0, ≈ −13 dB at 90° — high-freq end of natural ILD
+            Subtle   = 0,
+            Moderate = 1,
+            Strong   = 2,
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static float AsAlpha(IldProfile profile) =>
+            profile switch
+            {
+                IldProfile.Subtle => 1.2f, // α=1.2, ≈ −8 dB at 90° — average across voice band
+                IldProfile.Moderate => 1.5f, // α=1.5, ≈ −10 dB at 90° — slightly emphasized
+                _ => 2.0f, // α=2.0, ≈ −13 dB at 90° — high-freq end of natural ILD
+            };
 
         private static readonly ProfilerMarker markerSpatialPanningDSP = new ("LiveKit.Spatial.ILD.Exponential");
 
@@ -210,13 +219,9 @@ namespace LiveKit.Rooms.Streaming.Audio
 
             int samplesPerChannel = data.Length / channels;
 
-            float alpha = ildProfile switch
-            {
-                IldProfile.Subtle => 1.2f,
-                IldProfile.Moderate => 1.5f,
-                _ => 2.0f,
-            };
-            
+            float alpha = AsAlpha(ildProfile);
+
+
             float pan = math.sin(azimuth) * math.cos(elevation) * ildStrength;
             float gainL = math.exp(-alpha * math.max(0f, pan));
             float gainR = math.exp(-alpha * math.max(0f, -pan));

--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -13,8 +13,14 @@ namespace LiveKit.Rooms.Streaming.Audio
 {
     public class LivekitAudioSource : MonoBehaviour
     {
+        public enum IldProfile : byte
+        {
+            Subtle,   // α=1.2, ≈ −8 dB at 90° — average across voice band
+            Moderate, // α=1.5, ≈ −10 dB at 90° — slightly emphasized
+            Strong,   // α=2.0, ≈ −13 dB at 90° — high-freq end of natural ILD
+        }
+
         private static readonly ProfilerMarker markerSpatialPanningDSP = new ("LiveKit.Spatial.ILD.Exponential");
-        private const float ALPHA = 2.0f;
 
         private static ulong counter;
 
@@ -29,8 +35,14 @@ namespace LiveKit.Rooms.Streaming.Audio
         [Header("SPATIALIZATION")]
         [Tooltip("Enable L/R panning based on azimuth/elevation set via SetSpatialAngles.")]
         [SerializeField] private volatile bool spatialize;
+        
+        [Header("IDL")]
         [Tooltip("Interaural Level Difference (ILD) strength. 0 = no panning, 1 = full silence on far ear at 90°.")]
         [SerializeField, Range(0f, 1f)] private volatile float ildStrength = 0.75f;
+        [Tooltip("ILD attenuation curve at 90°: Subtle ≈ −8 dB (natural voice avg), Moderate ≈ −10 dB, Strong ≈ −13 dB (high-freq end).")]
+        [SerializeField] private IldProfile ildProfile = IldProfile.Strong;
+        
+        [Header("CLICK PREVENTION")]
         [Tooltip("Gain ramp duration in milliseconds at buffer start to prevent clicks on rapid azimuth changes. 0 = no ramp (cheapest, may click).")]
         [SerializeField, Range(0f, 30f)] private volatile float panningRampMs = 5f;
         [Tooltip("Min per-buffer gain change that activates the ramp. ~0.05 is an audible click; default 0.01 is a conservative threshold (5x safety margin). Lower = safer but more lerp work.")]
@@ -199,9 +211,16 @@ namespace LiveKit.Rooms.Streaming.Audio
 
             int samplesPerChannel = data.Length / channels;
 
+            float alpha = ildProfile switch
+            {
+                IldProfile.Subtle => 1.2f,
+                IldProfile.Moderate => 1.5f,
+                _ => 2.0f,
+            };
+            
             float pan = math.sin(azimuth) * math.cos(elevation) * ildStrength;
-            float gainL = math.exp(-ALPHA * math.max(0f, pan));
-            float gainR = math.exp(-ALPHA * math.max(0f, -pan));
+            float gainL = math.exp(-alpha * math.max(0f, pan));
+            float gainR = math.exp(-alpha * math.max(0f, -pan));
 
             float gainDelta = math.max(math.abs(gainL - prevGainL), math.abs(gainR - prevGainR));
             bool rampNeeded = panningRampMs > 0f && gainDelta > gainDeltaThreshold;

--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -228,7 +228,7 @@ namespace LiveKit.Rooms.Streaming.Audio
                 ? math.min((int)(panningRampMs * sampleRate * 0.001f), samplesPerChannel)
                 : 0;
 
-            // click smoothing for fast moves if panningRampMs are specified (>0)
+            // click smoothing for fast moves if rampNeeded
             {
                 float invRamp = 1f / rampLen;
 

--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -13,9 +13,9 @@ namespace LiveKit.Rooms.Streaming.Audio
 {
     public class LivekitAudioSource : MonoBehaviour
     {
-        private static readonly ProfilerMarker markerEqualPaowerDSP = new ("LiveKit.Spatial.ILD.EqualPower");
-        private const float HALF_PI = math.PI * 0.5f;
-        
+        private static readonly ProfilerMarker markerSpatialPanningDSP = new ("LiveKit.Spatial.ILD.Exponential");
+        private const float ALPHA = 2.0f;
+
         private static ulong counter;
 
         private int sampleRate;
@@ -23,8 +23,8 @@ namespace LiveKit.Rooms.Streaming.Audio
 
         private volatile float azimuth;
         private volatile float elevation;
-        private float prevGainL = 0.707f;
-        private float prevGainR = 0.707f;
+        private float prevGainL = 1.0f;
+        private float prevGainR = 1.0f;
 
         [Header("SPATIALIZATION")]
         [SerializeField] private volatile bool spatialize;
@@ -190,14 +190,13 @@ namespace LiveKit.Rooms.Streaming.Audio
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ApplySpatialPanning(float[] data, int channels)
         {
-            using var _ = markerEqualPaowerDSP.Auto();
+            using var _ = markerSpatialPanningDSP.Auto();
 
             int samplesPerChannel = data.Length / channels;
 
             float pan = math.sin(azimuth) * math.cos(elevation) * ildStrength;
-            float p = (pan + 1f) * 0.5f;
-            float gainL = math.cos(p * HALF_PI);
-            float gainR = math.sin(p * HALF_PI);
+            float gainL = math.exp(-ALPHA * math.max(0f, pan));
+            float gainR = math.exp(-ALPHA * math.max(0f, -pan));
 
             if (smoothPanning)
             {

--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -33,6 +33,8 @@ namespace LiveKit.Rooms.Streaming.Audio
         [SerializeField, Range(0f, 1f)] private volatile float ildStrength = 0.75f;
         [Tooltip("Gain ramp duration in milliseconds at buffer start to prevent clicks on rapid azimuth changes. 0 = no ramp (cheapest, may click).")]
         [SerializeField, Range(0f, 30f)] private volatile float panningRampMs = 5f;
+        [Tooltip("Min per-buffer gain change that activates the ramp. ~0.05 is an audible click; default 0.01 is a conservative threshold (5x safety margin). Lower = safer but more lerp work.")]
+        [SerializeField, Range(0f, 0.1f)] private volatile float gainDeltaThreshold = 0.01f;
         
         private WavWriter? wavWriter;
         private PCMSample[] wavBuffer = Array.Empty<PCMSample>();
@@ -201,7 +203,9 @@ namespace LiveKit.Rooms.Streaming.Audio
             float gainL = math.exp(-ALPHA * math.max(0f, pan));
             float gainR = math.exp(-ALPHA * math.max(0f, -pan));
 
-            int rampLen = panningRampMs > 0f
+            float gainDelta = math.max(math.abs(gainL - prevGainL), math.abs(gainR - prevGainR));
+            bool rampNeeded = panningRampMs > 0f && gainDelta > gainDeltaThreshold;
+            int rampLen = rampNeeded
                 ? math.min((int)(panningRampMs * sampleRate * 0.001f), samplesPerChannel)
                 : 0;
 

--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -27,9 +27,12 @@ namespace LiveKit.Rooms.Streaming.Audio
         private float prevGainR = 1.0f;
 
         [Header("SPATIALIZATION")]
+        [Tooltip("Enable L/R panning based on azimuth/elevation set via SetSpatialAngles.")]
         [SerializeField] private volatile bool spatialize;
+        [Tooltip("Interaural Level Difference (ILD) strength. 0 = no panning, 1 = full silence on far ear at 90°.")]
         [SerializeField, Range(0f, 1f)] private volatile float ildStrength = 0.75f;
-        [SerializeField] private volatile bool smoothPanning;
+        [Tooltip("Gain ramp duration in milliseconds at buffer start to prevent clicks on rapid azimuth changes. 0 = no ramp (cheapest, may click).")]
+        [SerializeField, Range(0f, 30f)] private volatile float panningRampMs = 5f;
         
         private WavWriter? wavWriter;
         private PCMSample[] wavBuffer = Array.Empty<PCMSample>();
@@ -53,11 +56,11 @@ namespace LiveKit.Rooms.Streaming.Audio
             this.elevation = elevation;
         }
 
-        public void SetSpatialSettings(bool spatialize, float ildStrength, bool smoothPanning)
+        public void SetSpatialSettings(bool spatialize, float ildStrength, float panningRampMs)
         {
             this.spatialize = spatialize;
             this.ildStrength = ildStrength;
-            this.smoothPanning = smoothPanning;
+            this.panningRampMs = panningRampMs;
         }
 
         public void Construct(Weak<AudioStream> audioStream)
@@ -198,22 +201,27 @@ namespace LiveKit.Rooms.Streaming.Audio
             float gainL = math.exp(-ALPHA * math.max(0f, pan));
             float gainR = math.exp(-ALPHA * math.max(0f, -pan));
 
-            if (smoothPanning)
-            {
-                float invLen = 1f / samplesPerChannel;
+            int rampLen = panningRampMs > 0f
+                ? math.min((int)(panningRampMs * sampleRate * 0.001f), samplesPerChannel)
+                : 0;
 
-                for (int i = 0; i < samplesPerChannel; i++)
+            // click smoothing for fast moves if panningRampMs are specified (>0)
+            {
+                float invRamp = 1f / rampLen;
+
+                for (int i = 0; i < rampLen; i++)
                 {
-                    float t = i * invLen;
+                    float t = i * invRamp;
                     int offset = i * channels;
                     float mono = data[offset];
                     data[offset]     = mono * math.lerp(prevGainL, gainL, t);
                     data[offset + 1] = mono * math.lerp(prevGainR, gainR, t);
                 }
             }
-            else
+
+            // basic panning
             {
-                for (int i = 0; i < samplesPerChannel; i++)
+                for (int i = rampLen; i < samplesPerChannel; i++)
                 {
                     int offset = i * channels;
                     float mono = data[offset];
@@ -221,7 +229,7 @@ namespace LiveKit.Rooms.Streaming.Audio
                     data[offset + 1] = mono * gainR;
                 }
             }
-            
+
             prevGainL = gainL;
             prevGainR = gainR;
         }

--- a/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/LivekitAudioSource.cs
@@ -70,11 +70,10 @@ namespace LiveKit.Rooms.Streaming.Audio
             this.elevation = elevation;
         }
 
-        public void SetSpatialSettings(bool spatialize, float ildStrength, float panningRampMs)
+        public void SetSpatialSettings(bool spatialize, float ildStrength)
         {
             this.spatialize = spatialize;
             this.ildStrength = ildStrength;
-            this.panningRampMs = panningRampMs;
         }
 
         public void Construct(Weak<AudioStream> audioStream)


### PR DESCRIPTION
## Summary

Spatial audio panning fixes for voice chat:
- **Loudness:** Spatial mode no longer attenuates the signal at center position. Both channels reach unity gain when the speaker is in front, matching Mono / Community Voice Chat loudness (was −3 dB due to equal-power 0.707 floor).
- **Clicks:** Click artifacts on rapid camera rotation eliminated via a short gain ramp (~5 ms) at the start of each audio buffer. Ramp is skipped automatically when gain change is below audible threshold (saves CPU when source is stationary).

Companion PR: https://github.com/decentraland/unity-explorer/pull/8610

## What changed (technical)

- Replaced equal-power \`cos/sin\` panning law with exponential ILD curve: \`gainFar = exp(-α·|pan|)\`, \`gainNear = 1.0\`
- Default \`α = 2.0\` (\`Strong\` profile) → far ear at 90° ≈ −13 dB
- Added click-free linear ramp at buffer start; auto-bypass via \`Δgain\` threshold
- Inspector knobs added (build-irrelevant): \`IldProfile\` enum, \`panningRampMs\`, \`gainDeltaThreshold\`
