### PR TITLE
fix: clamp audio input channels to stereo to prevent WebRTC crash

### DIFF
--- a/Runtime/Scripts/RtcSources/Audio/MicrophoneRtcAudioSource.cs
+++ b/Runtime/Scripts/RtcSources/Audio/MicrophoneRtcAudioSource.cs
@@ -70,7 +70,9 @@ namespace LiveKit.Audio
             using var request = FFIBridge.Instance.NewRequest<NewAudioSourceRequest>();
             var newAudioSource = request.request;
             newAudioSource.Type = AudioSourceType.AudioSourceNative;
-            newAudioSource.NumChannels = deviceMicrophoneAudioSource.MicrophoneInfo.channels;
+            // Clamp to stereo — voice chat only needs mono/stereo, and the
+            // underlying WebRTC AudioFrame crashes with >8 channels.
+            newAudioSource.NumChannels = Math.Min(deviceMicrophoneAudioSource.MicrophoneInfo.channels, 2);
             newAudioSource.SampleRate = SampleRate.Hz48000.valueHz;
 
             using var options = request.TempResource<AudioSourceOptions>();

--- a/RustAudio/rust-audio/src/lib.rs
+++ b/RustAudio/rust-audio/src/lib.rs
@@ -333,7 +333,13 @@ fn rust_audio_input_stream_new_internal(device_name: &str) -> Result<(StreamId, 
         .find(|c| c.sample_format() == cpal::SampleFormat::F32)
         .ok_or(anyhow!("device doesn't support f32 samples"))?;
 
-    let config = config_range.with_max_sample_rate().config();
+    let mut config = config_range.with_max_sample_rate().config();
+
+    // Clamp to stereo — voice chat only needs mono/stereo, and WebRTC's
+    // AudioFrame asserts num_channels <= kMaxConcurrentChannels (8).
+    // Multi-channel audio interfaces (e.g. Scarlett 18i20 with 20 channels)
+    // would otherwise cause a fatal crash.
+    config.channels = config.channels.min(2);
 
     let next_id = NEXT_STREAM_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let moved_id = next_id;


### PR DESCRIPTION
## Summary

- Clamps audio input channel count to 2 (stereo) in the Rust cpal capture layer (lib.rs)
- Adds a defensive clamp in C# MicrophoneRtcAudioSource when creating the LiveKit audio source
- Prevents fatal WebRTC AudioFrame assertion (num_channels <= kMaxConcurrentChannels) with multi-channel audio interfaces

## Problem

Multi-channel audio interfaces (e.g. Focusrite Scarlett 18i20 with 20 output channels) cause a fatal process crash when used as the system audio device. The Rust audio capture code takes whatever channel count cpal reports from the device without any limit. This channel count flows through to WebRTC AudioFrame, which has a hard assertion that num_channels <= 8 (kMaxConcurrentChannels). The process aborts immediately:

```
Fatal error in: ../api/audio/audio_frame.cc, line 75
Check failed: num_channels <= kMaxConcurrentChannels (20 vs. 8)
```

## Fix

Voice chat only needs mono or stereo audio. The fix clamps the channel count at two levels:

1. **Rust (RustAudio/rust-audio/src/lib.rs)**: config.channels = config.channels.min(2) -- prevents cpal from capturing unnecessary channels
2. **C# (MicrophoneRtcAudioSource.cs)**: Math.Min(channels, 2) -- safety net at LiveKit audio source creation

This avoids needing to update the bundled WebRTC fork.

## Affected devices

Any audio interface reporting >8 channels: Focusrite Scarlett 18i20, Universal Audio Apollo, MOTU 828/1248, RME Fireface, or aggregate audio devices.

Fixes decentraland/unity-explorer#8766

## Test plan

- [ ] Verify voice chat works with a standard stereo audio device (no regression)
- [ ] Verify voice chat works with a multi-channel audio interface (e.g. Scarlett 18i20) -- should no longer crash
- [ ] Verify microphone input is correctly captured as mono/stereo even when the device supports more channels