### PR TITLE
Fix/no explicit dispose

### DIFF
--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -153,26 +153,17 @@ namespace LiveKit.Internal
             }
 
             isDisposed = true;
+
+            // Stop all rooms synchronously
+            // The rust lk implementation should also correctly dispose WebRTC
             initialized = false;
-            Utils.Debug("FFIServer - Disposed. Dropping the native part is skiped");
-            // silent drop reason:
-            // https://github.com/livekit/rust-sdks/blob/main/livekit-ffi/src/server/requests.rs
-            //
-            /// Dispose the server, close all rooms and clean up all handles
-            /// It is not mandatory to call this function.
-            /// fn on_dispose(
-            ///     server: &'static FfiServer,
-            ///     dispose: proto::DisposeRequest,
-            /// ) -> FfiResult<proto::DisposeResponse> {
-            ///     *server.config.lock() = None;
-            /// 
-            ///     if !dispose.r#async {
-            ///         server.async_runtime.block_on(server.dispose());
-            ///         Ok(proto::DisposeResponse::default())
-            ///     } else {
-            ///         todo!("async dispose");
-            ///     }
-            /// }
+            SendRequest(
+                new FfiRequest
+                {
+                    Dispose = new DisposeRequest()
+                }
+            );
+            Utils.Debug("FFIServer - Disposed");
         }
 
         public void Release(FfiResponse response)

--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -221,6 +221,9 @@ namespace LiveKit.Internal
             return;
 #endif
 
+            // Prevents app freeze on exit due the registered threads via IL2CPP context
+            // We already had this issue before and the full explanation is here:
+            // https://support.unity.com/hc/en-us/requests/3055850
             System.Threading.Thread current = System.Threading.Thread.CurrentThread;
             if (current.IsBackground == false) current.IsBackground = true;
 

--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -153,17 +153,26 @@ namespace LiveKit.Internal
             }
 
             isDisposed = true;
-
-            // Stop all rooms synchronously
-            // The rust lk implementation should also correctly dispose WebRTC
             initialized = false;
-            SendRequest(
-                new FfiRequest
-                {
-                    Dispose = new DisposeRequest()
-                }
-            );
-            Utils.Debug("FFIServer - Disposed");
+            Utils.Debug("FFIServer - Disposed. Dropping the native part is skiped");
+            // silent drop reason:
+            // https://github.com/livekit/rust-sdks/blob/main/livekit-ffi/src/server/requests.rs
+            //
+            /// Dispose the server, close all rooms and clean up all handles
+            /// It is not mandatory to call this function.
+            /// fn on_dispose(
+            ///     server: &'static FfiServer,
+            ///     dispose: proto::DisposeRequest,
+            /// ) -> FfiResult<proto::DisposeResponse> {
+            ///     *server.config.lock() = None;
+            /// 
+            ///     if !dispose.r#async {
+            ///         server.async_runtime.block_on(server.dispose());
+            ///         Ok(proto::DisposeResponse::default())
+            ///     } else {
+            ///         todo!("async dispose");
+            ///     }
+            /// }
         }
 
         public void Release(FfiResponse response)

--- a/Runtime/Scripts/Internal/FFIClient.cs
+++ b/Runtime/Scripts/Internal/FFIClient.cs
@@ -126,7 +126,7 @@ namespace LiveKit.Internal
             {
             }
 
-            Utils.Debug("FFIServer - Initialized");
+            Utils.Debug($"FFIServer - Initialized, capture logs: {captureLogs}");
             initialized = true;
         }
 
@@ -198,7 +198,7 @@ namespace LiveKit.Internal
                         NativeMethods.FfiDropHandle(handle);
 
 #if LK_VERBOSE
-                        Debug.Log($"FFIClient response of type: {response.MessageCase} with asyncId: {AsyncId(response)}");
+                        Utils.Debug($"FFIClient response of type: {response.MessageCase} with asyncId: {AsyncId(response)}");
 #endif
 
                         return response;
@@ -221,6 +221,9 @@ namespace LiveKit.Internal
             return;
 #endif
 
+            System.Threading.Thread current = System.Threading.Thread.CurrentThread;
+            if (current.IsBackground == false) current.IsBackground = true;
+
             try
             {
                 if (isDisposed) return;
@@ -235,7 +238,7 @@ namespace LiveKit.Internal
                 {
                     case FfiEvent.MessageOneofCase.Logs:
 
-                        Debug.Log($"LK_DEBUG: {response.Logs.Records}");
+                        Utils.Debug($"LK_DEBUG: {response.Logs.Records}");
                         break;
                     case FfiEvent.MessageOneofCase.PublishData:
                         break;

--- a/Runtime/Scripts/Internal/Utils.cs
+++ b/Runtime/Scripts/Internal/Utils.cs
@@ -18,12 +18,12 @@ namespace LiveKit.Internal
         [Conditional(LK_DEBUG)]
         public static void Debug(object msg)
         {
-            UnityEngine.Debug.unityLogger.Log(LogType.Log, $"{PREFIX}: {msg}");
+            UnityEngine.Debug.unityLogger.Log(LogType.Log, $"{PREFIX}: {DateTime.UtcNow:HH:mm:ss.fff} : {msg}");
         }
 
         public static void Error(object msg)
         {
-            UnityEngine.Debug.unityLogger.Log(LogType.Error, $"{PREFIX}: {msg}");
+            UnityEngine.Debug.unityLogger.Log(LogType.Error, $"{PREFIX}: {DateTime.UtcNow:HH:mm:ss.fff} : {msg}");
         }
 
         public static GraphicsFormat GetSupportedGraphicsFormat(GraphicsDeviceType type)


### PR DESCRIPTION
## What does this PR change?

Prevents LiveKit FFI callback threads from blocking Unity's application exit by marking them as background threads, and standardizes internal logging through `Utils.Debug` with UTC timestamps.

### Problem

When Unity's `Application.Quit()` is called, the runtime waits for all **foreground** threads to complete before the process can exit. The LiveKit native SDK spawns threads for FFI callbacks (`FFICallback`), and these threads remain as foreground threads by default. If a callback is in-flight or the native SDK keeps dispatching events during shutdown, the application hangs — contributing to the exit delay investigated in [unity-explorer#8770](https://github.com/decentraland/unity-explorer/pull/8770).

Additionally, some log calls in `FFIClient` used `Debug.Log` directly instead of the SDK's own `Utils.Debug` wrapper, bypassing the `LK_DEBUG` conditional compilation and lacking consistent formatting.

### Solution

**Background thread marking (`FFIClient.FFICallback`):**
- At the entry point of `FFICallback`, checks `Thread.CurrentThread.IsBackground` and sets it to `true` if it isn't already.
- This ensures that any thread the native LiveKit SDK uses to invoke the callback will not prevent the CLR/Mono runtime from exiting when `Application.Quit()` is called.
- The check is idempotent — setting `IsBackground` on an already-background thread is a no-op.

**Logging standardization:**
- Replaced three `Debug.Log` calls in `FFIClient.cs` with `Utils.Debug` to route them through the SDK's conditional (`LK_DEBUG`) logging path.
- Added the `captureLogs` flag value to the initialization log for easier diagnostics.
- Added UTC timestamps (`HH:mm:ss.fff`) to both `Utils.Debug` and `Utils.Error` output for better correlation with exit timing diagnostics.

### Note

An initial approach (`silent drop fix`) was attempted and reverted in favor of the current, simpler background-thread solution.

> **DO NOT MERGE YET** — pending validation with [unity-explorer#8770](https://github.com/decentraland/unity-explorer/pull/8770).

## Test Instructions

1. Integrate this branch into a unity-explorer build (already referenced in unity-explorer#8770 via `manifest.json`).
2. Launch the Explorer, enter a world, then quit the application.
3. Verify the application exits promptly without hanging.
4. Check logs for LiveKit `[LK]` prefixed messages — they should include UTC timestamps.
5. Verify no regressions in LiveKit comms (voice/data channels) during normal gameplay.

## Quality Checklist
- [ ] Changes have been tested locally
- [ ] No regressions in LiveKit connectivity
- [ ] Exit timing validated with unity-explorer#8770