### PR TITLE
feat: AudioStream | expose frame-activity oracle (LastFrameReceivedAt)

### DIFF
--- a/Runtime/Scripts/Rooms/Streaming/Audio/AudioStream.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/AudioStream.cs
@@ -28,6 +28,8 @@ namespace LiveKit.Rooms.Streaming.Audio
 
         public WavTeeControl WavTeeControl => currentInternal.WavTeeControl;
 
+        public int LastFrameReceivedAt => currentInternal.LastFrameReceivedAt;
+
         public AudioStream(StreamKey streamKey, LiveKit.Rooms.Tracks.ITrack track)
         {
             this.streamKey = streamKey;
@@ -106,10 +108,13 @@ namespace LiveKit.Rooms.Streaming.Audio
             );
 
         private bool disposed;
+        private int lastFrameReceivedAt = -1;
 
         public readonly AudioStreamInfo audioStreamInfo;
         private readonly uint internalChannels;
         private readonly uint internalSampleRate;
+
+        public int LastFrameReceivedAt => Volatile.Read(ref lastFrameReceivedAt);
 
         public WavTeeControl WavTeeControl
         {
@@ -221,6 +226,8 @@ namespace LiveKit.Rooms.Streaming.Audio
                 );
                 return;
             }
+
+            Volatile.Write(ref lastFrameReceivedAt, Environment.TickCount);
 
             using var guard = buffer.Lock();
             guard.Value.Write(frame);

--- a/Runtime/Scripts/Rooms/Streaming/Audio/AudioStream.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/AudioStream.cs
@@ -28,7 +28,7 @@ namespace LiveKit.Rooms.Streaming.Audio
 
         public WavTeeControl WavTeeControl => currentInternal.WavTeeControl;
 
-        public int LastFrameReceivedAt => currentInternal.LastFrameReceivedAt;
+        public Option<int> LastFrameReceivedAt => currentInternal.LastFrameReceivedAt;
 
         public AudioStream(StreamKey streamKey, LiveKit.Rooms.Tracks.ITrack track)
         {
@@ -108,13 +108,20 @@ namespace LiveKit.Rooms.Streaming.Audio
             );
 
         private bool disposed;
-        private int lastFrameReceivedAt = -1;
+        private int volatileLastFrameReceivedAt = -1;
 
         public readonly AudioStreamInfo audioStreamInfo;
         private readonly uint internalChannels;
         private readonly uint internalSampleRate;
 
-        public int LastFrameReceivedAt => Volatile.Read(ref lastFrameReceivedAt);
+        public Option<int> LastFrameReceivedAt
+        {
+            get
+            {
+                int value = Volatile.Read(ref volatileLastFrameReceivedAt);
+                return value == -1 ? Option<int>.None : Option<int>.Some(value);
+            }
+        }
 
         public WavTeeControl WavTeeControl
         {
@@ -227,7 +234,7 @@ namespace LiveKit.Rooms.Streaming.Audio
                 return;
             }
 
-            Volatile.Write(ref lastFrameReceivedAt, Environment.TickCount);
+            Volatile.Write(ref volatileLastFrameReceivedAt, Environment.TickCount);
 
             using var guard = buffer.Lock();
             guard.Value.Write(frame);

--- a/Runtime/Scripts/Rooms/Streaming/Audio/AudioStreams.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/AudioStreams.cs
@@ -22,6 +22,12 @@ namespace LiveKit.Rooms.Streaming.Audio
         {
             return stream.AudioStreamInfo;
         }
+
+        public int GetLastFrameReceivedAt(StreamKey streamKey)
+        {
+            var weak = ActiveStream(streamKey);
+            return weak.Resource.Has ? weak.Resource.Value.LastFrameReceivedAt : -1;
+        }
     }
 }
 

--- a/Runtime/Scripts/Rooms/Streaming/Audio/AudioStreams.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/AudioStreams.cs
@@ -22,12 +22,6 @@ namespace LiveKit.Rooms.Streaming.Audio
         {
             return stream.AudioStreamInfo;
         }
-
-        public int GetLastFrameReceivedAt(StreamKey streamKey)
-        {
-            var weak = ActiveStream(streamKey);
-            return weak.Resource.Has ? weak.Resource.Value.LastFrameReceivedAt : -1;
-        }
     }
 }
 

--- a/Runtime/Scripts/Rooms/Streaming/Audio/IAudioStreams.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/IAudioStreams.cs
@@ -4,7 +4,7 @@ namespace LiveKit.Rooms.Streaming.Audio
 {
     public interface IAudioStreams : IStreams<AudioStream, AudioStreamInfo>
     {
-        
+        int GetLastFrameReceivedAt(StreamKey streamKey);
     }
 }
 

--- a/Runtime/Scripts/Rooms/Streaming/Audio/IAudioStreams.cs
+++ b/Runtime/Scripts/Rooms/Streaming/Audio/IAudioStreams.cs
@@ -1,10 +1,20 @@
-﻿#if !UNITY_WEBGL || UNITY_EDITOR
+#if !UNITY_WEBGL || UNITY_EDITOR
+
+using RichTypes;
 
 namespace LiveKit.Rooms.Streaming.Audio
 {
     public interface IAudioStreams : IStreams<AudioStream, AudioStreamInfo>
     {
-        int GetLastFrameReceivedAt(StreamKey streamKey);
+    }
+
+    public static class AudioStreamsExtensions
+    {
+        public static Option<int> GetLastFrameReceivedAt(this IAudioStreams streams, StreamKey streamKey)
+        {
+            var weak = streams.ActiveStream(streamKey);
+            return weak.Resource.Has ? weak.Resource.Value.LastFrameReceivedAt : Option<int>.None;
+        }
     }
 }
 


### PR DESCRIPTION
  Add a cheap monotonic timestamp on every AudioStream that ticks inside the FFI callback whenever a media frame is decoded. This is  the foundation for the NearbyVoiceChat single-active-sid resolver (stream deduplication): a stream that's alive is decoding frames; a ghost never decodes.

  - AudioStreamInternal: private `lastFrameReceivedAt` (init -1), Volatile.Read/Write around Environment.TickCount, set right before the buffer write under the existing channel/sampleRate guards.
  - AudioStream: pass-through `LastFrameReceivedAt`.
  - IAudioStreams.GetLastFrameReceivedAt(StreamKey): returns -1 when the stream is missing or has never emitted (sentinel chosen over 0 because TickCount is signed and can legitimately be 0/negative).

explorer consumer - https://github.com/decentraland/unity-explorer/pull/8817